### PR TITLE
Improve debugging

### DIFF
--- a/src/dependencies/scheme_interpreter/scheme.c
+++ b/src/dependencies/scheme_interpreter/scheme.c
@@ -1472,11 +1472,15 @@ INTERFACE void putstr(scheme *sc, const char *s) {
   if (pt->kind & port_file) {
     fputs(s, pt->rep.stdio.file);
   } else {
+#if SBPL_DEBUG
+    fprintf(stderr, "%s", s);
+#else
     for (; *s; s++) {
       if (pt->rep.string.curr != pt->rep.string.past_the_end) {
         *pt->rep.string.curr++ = *s;
       }
     }
+#endif
   }
 }
 
@@ -1486,9 +1490,13 @@ static void putchars(scheme *sc, const char *s, int len) {
     fwrite(s, 1, len, pt->rep.stdio.file);
   } else {
     for (; len; len--) {
+#if SBPL_DEBUG
+      fprintf(stderr, "%c", *s++);
+#else
       if (pt->rep.string.curr != pt->rep.string.past_the_end) {
         *pt->rep.string.curr++ = *s++;
       }
+#endif
     }
   }
 }
@@ -1498,9 +1506,13 @@ INTERFACE void putcharacter(scheme *sc, int c) {
   if (pt->kind & port_file) {
     fputc(c, pt->rep.stdio.file);
   } else {
+#if SBPL_DEBUG
+    fprintf(stderr, "%c", c);
+#else
     if (pt->rep.string.curr != pt->rep.string.past_the_end) {
       *pt->rep.string.curr++ = c;
     }
+#endif
   }
 }
 

--- a/src/dependencies/scheme_interpreter/scheme.h
+++ b/src/dependencies/scheme_interpreter/scheme.h
@@ -8,6 +8,10 @@
 extern "C" {
 #endif
 
+#ifndef SBPL_DEBUG
+#define SBPL_DEBUG 0
+#endif
+
 /*
  * Default values for #define'd symbols
  */

--- a/src/sb/actions.c
+++ b/src/sb/actions.c
@@ -89,6 +89,7 @@ static pointer sbpl_create_rule(scheme *sc, pointer args) {
   for (size_t i = 1; i < nargs; ++i) {
     pointer next_arg = scheme_arguments.next(sc, &args);
 
+    assert(next_arg != sc->NIL);
     assert(is_blob(next_arg));
 
     blob_info_t bi = blob_info(next_arg);


### PR DESCRIPTION
First, I added an assertion that is triggered if an argument to an action is a NIL pointer. Since, NIL pointers are sentinel objects, you do not quickly spot them in an interactive debugger session.

The assertion in the next line is triggered implicitly in that case.
https://github.com/0xbf00/simbple/blob/e9ea6c70c0bc8f792b3e16a152867c9786db6310/src/sb/actions.c#L92

Second, In order to debug the TinyScheme interpreter, you can enable tracing by
adding the following line in your Scheme code:

```scheme
(tracing 1)
```
Unfortunately, this results in crashes that look like memory handling issues in TinyScheme itself. I have not investigated the crashes further and simply added a workaround, which can be compiled in by passing `-DSBPL_DEBUG=1` to `cmake`. The trace will then be simply written to `stderr`. This is probably undesired for a general purpose interpreter, however, it is sufficient in our use case.