### PR TITLE
Avoid verification unless Scheme is used as output format

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -75,6 +75,8 @@ static int parse_opt(int key, char *arg, struct argp_state *state) {
       argp_failure(state, 1, 0, "Incorrect platform specified.");
     if (state->arg_num > 1)
       argp_failure(state, 1, 0, "At most one container metadata file allowed.");
+    if (!args->scheme_output && args->should_verify)
+      argp_failure(state, 1, 0, "Only Scheme output can be verified.");
   }
   }
 


### PR DESCRIPTION
Verification passes the generated output to the SBPL compiler. Setting `--json` in combination with `--verify` will lead the to SBPL compiler trying to compile the generated JSON, which obviously fails.